### PR TITLE
add comtable to debian testing and ubuntu 14.04

### DIFF
--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= name %>
 Version: <%= version %>
-Depends: git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11, libnotify4, libxtst6, libnss3, python, gvfs-bin, xdg-utils
+Depends: git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, python, gvfs-bin, xdg-utils
 Suggests: libgnome-keyring0, gir1.2-gnomekeyring-1.0
 Section: <%= section %>
 Priority: optional


### PR DESCRIPTION
- libgcrypt11-dev  on debian is a dammy file "shortcut" to libgcrypt20 . so to make possible to install atom on debian testing version  we should  add on depends *\* libgcrypt20.

libgcrypt20 has  backward compatibility to libgcrypt11 .

*\* libgcrypt20 is comfortable  with  debian unstable/testing ,  and ubuntu 14.04TLS  .
- libgcrypt11 (without -dev) not exists on debian testing and makeing  bugs with atom deb file .

sources:

https://packages.debian.org/search?searchon=names&keywords=libgcrypt20

http://packages.ubuntu.com/search?keywords=libgcrypt20&searchon=names

https://packages.debian.org/source/wheezy/libgcrypt11

http://packages.ubuntu.com/precise/libgcrypt11
